### PR TITLE
Add interactive buttons to new event notifications

### DIFF
--- a/cmd/vga-events-telegram/main.go
+++ b/cmd/vga-events-telegram/main.go
@@ -160,11 +160,12 @@ func main() {
 	if *dryRun {
 		fmt.Printf("DRY RUN MODE - Would send %d messages:\n\n", len(events))
 		for i, evt := range events {
-			msg, _ := telegram.FormatEventWithCalendar(evt)
+			msg, keyboard := telegram.FormatEventWithStatus(evt, "")
 			fmt.Printf("--- Message %d/%d ---\n", i+1, len(events))
 			fmt.Println(msg)
 			fmt.Printf("\n(Length: %d characters)\n", len(msg))
-			fmt.Printf("Calendar button: 📅 Add to Calendar (callback: calendar:%s)\n\n", evt.ID)
+			fmt.Printf("Buttons: 📅 Calendar, ⭐ Interested, ✅ Registered, 🤔 Maybe, ❌ Skip\n\n")
+			_ = keyboard // keyboard is used but we're showing simplified output
 		}
 		os.Exit(0)
 	}
@@ -186,7 +187,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Send messages with calendar buttons
+	// Send messages with interactive buttons
 	for i, evt := range events {
 		var msg string
 		var keyboard *telegram.InlineKeyboardMarkup
@@ -195,7 +196,8 @@ func main() {
 		if *checkReminders {
 			msg, keyboard = telegram.FormatReminder(evt, *reminderDays)
 		} else {
-			msg, keyboard = telegram.FormatEventWithCalendar(evt)
+			// Use status keyboard for new events (same as /my-events)
+			msg, keyboard = telegram.FormatEventWithStatus(evt, "")
 		}
 
 		if err := client.SendMessageWithKeyboard(msg, keyboard); err != nil {


### PR DESCRIPTION
Makes new event notifications have the same interactive buttons as `/my-events` and reminders, creating a consistent user experience.

## Problem

When users receive **new event notifications**, they only get a "📅 Add to Calendar" button:

```
🏌️ New VGA Golf Event!

📍 NV - Stallion Mountain
📅 Saturday, Feb 15, 2026
🏢 Las Vegas

[📅 Add to Calendar]  ← only button
```

But when viewing events via `/my-events` or receiving **reminders**, they get full interactive buttons:

```
🏌️ Event Reminder!

📍 NV - Stallion Mountain
📅 Saturday, Feb 15, 2026

[📅 Calendar]
[⭐ Interested] [✅ Registered]
[🤔 Maybe] [❌ Skip]  ← full status tracking
```

This inconsistency is confusing and requires users to run `/my-events` to interact with new events.

## Solution

Changed new event notifications to use `FormatEventWithStatus()` instead of `FormatEventWithCalendar()`.

## After This PR

All event notifications (new events, reminders, /my-events) now show the same interactive buttons:

- **📅 Calendar** - Download .ics file
- **⭐ Interested** - Mark as interested
- **✅ Registered** - Mark as registered
- **🤔 Maybe** - Mark as maybe
- **❌ Skip** - Mark to skip

## Benefits

1. **Consistent UX** - Same buttons across all event notifications
2. **Immediate action** - Users can respond to new events right away
3. **Reduces friction** - No need to run `/my-events` to mark interest
4. **Better engagement** - Easier to track event status

## Testing

- [x] All tests pass
- [x] Code compiles successfully
- [x] Dry run mode updated to show new buttons
- [x] Uses existing `FormatEventWithStatus()` function (well-tested)

## Code Changes

**File**: `cmd/vga-events-telegram/main.go`

```diff
- msg, keyboard = telegram.FormatEventWithCalendar(evt)
+ msg, keyboard = telegram.FormatEventWithStatus(evt, "")
```

Small change, big UX improvement!

🤖 Generated with [Claude Code](https://claude.com/claude-code)