### PR TITLE
Fix: Pass golf API key to vga-events-telegram in workflow

### DIFF
--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -160,7 +160,7 @@ jobs:
                 echo "  Sending $EVENT_COUNT new event(s) immediately to user $CHAT_ID..."
 
                 # Send events with time-based filtering
-                if ./vga-events-telegram --chat-id "$CHAT_ID" --events-file "user_events_${CHAT_ID}.json" --max-messages 10 --hide-past="$HIDE_PAST" --days-ahead="$DAYS_AHEAD"; then
+                if ./vga-events-telegram --chat-id "$CHAT_ID" --events-file "user_events_${CHAT_ID}.json" --max-messages 10 --hide-past="$HIDE_PAST" --days-ahead="$DAYS_AHEAD" --golf-api-key "$GOLF_COURSE_API_KEY"; then
                   echo "  ✅ Successfully sent events"
 
                   # Mark events as seen by adding their IDs with timestamps to preferences


### PR DESCRIPTION
## Problem
The Golf Course API integration wasn't working in production. Course info was not appearing in Telegram notifications despite the feature being deployed in v0.5.0.

## Root Cause
The `GOLF_COURSE_API_KEY` environment variable was set in the workflow (line 99) but not passed as a command-line flag to `vga-events-telegram`, so the binary never received the API key.

## Solution
Added `--golf-api-key "$GOLF_COURSE_API_KEY"` flag to the `vga-events-telegram` command on line 163.

## Testing
After merge, restart the telegram-bot.yml workflow to test with real events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)