### PR TITLE
Fix: Deduplicate golf course tees by name

### DIFF
--- a/cmd/vga-events-telegram/main.go
+++ b/cmd/vga-events-telegram/main.go
@@ -131,16 +131,21 @@ func getCourseDetailsForEvent(client *course.Client, evt *event.Event) *telegram
 	}
 
 	// Collect all tees (combined, no distinction between gender)
+	// Deduplicate by tee name - keep first occurrence (male tees come first)
+	seenTees := make(map[string]bool)
 	var tees []telegram.TeeDetails
 	for _, tee := range append(courseInfo.Tees.Male, courseInfo.Tees.Female...) {
-		tees = append(tees, telegram.TeeDetails{
-			Name:    tee.TeeName,
-			Par:     tee.ParTotal,
-			Yardage: tee.TotalYards,
-			Slope:   tee.SlopeRating,
-			Rating:  tee.CourseRating,
-			Holes:   tee.NumberOfHoles,
-		})
+		if !seenTees[tee.TeeName] {
+			seenTees[tee.TeeName] = true
+			tees = append(tees, telegram.TeeDetails{
+				Name:    tee.TeeName,
+				Par:     tee.ParTotal,
+				Yardage: tee.TotalYards,
+				Slope:   tee.SlopeRating,
+				Rating:  tee.CourseRating,
+				Holes:   tee.NumberOfHoles,
+			})
+		}
 	}
 
 	if len(tees) == 0 {

--- a/internal/telegram/formatter.go
+++ b/internal/telegram/formatter.go
@@ -130,14 +130,6 @@ func FormatEventWithCourse(evt *event.Event, course *CourseDetails, note string)
 		if course.Phone != "" {
 			msg.WriteString(fmt.Sprintf("📞 %s\n", course.Phone))
 		}
-	} else {
-		// DEBUG: Show why course info is missing
-		msg.WriteString("\n")
-		if course == nil {
-			msg.WriteString("🔍 <i>Debug: course=nil</i>\n")
-		} else if len(course.Tees) == 0 {
-			msg.WriteString(fmt.Sprintf("🔍 <i>Debug: course=%s, tees=0</i>\n", course.Name))
-		}
 	}
 
 	// Note (if available)


### PR DESCRIPTION
## Problem
Course tees were being duplicated when male and female tees had the same name (e.g., White, Gold, Teal). The Golf Course API returns separate male and female tee data, and we were just appending them together without deduplication.

## Solution
- Added deduplication logic using a `seenTees` map
- Keeps first occurrence of each tee name (male tees come first)
- Applied to both `vga-events-bot` and `vga-events-telegram` binaries

## Cleanup
- Removed debug logging from `getCourseDetails()` 
- Removed user-facing debug messages from formatter
- Simplified API initialization message

## Result
Users now see 6 unique tees instead of 10 (6 male + 4 duplicate female tees):
- Black, Blue, White, Gold, Gold/Teal, Teal

🤖 Generated with [Claude Code](https://claude.com/claude-code)